### PR TITLE
Return last result of a retried operation which is never successful 

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -8,14 +8,17 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up Clojure
-        uses: DeLaGuardo/setup-clojure@v2
+        uses: DeLaGuardo/setup-clojure@10.1
         with:
           tools-deps: 'latest'
+          cli: 'latest'
+
       - name: Cache Clojure dependencies
         uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-clojure-${{ hashFiles('**/deps.edn') }}
+
       - name: Run Clojure tests
         run: clojure -M:dev:test
 
@@ -28,7 +31,9 @@ jobs:
         with:
           node-version: '18'
           cache: 'npm'
+
       - name: Install shadow-cljs
         run: npm install shadow-cljs
+
       - name: Run ClojureScript tests
         run: npx shadow-cljs compile node-test

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -6,15 +6,15 @@ jobs:
   clojure-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Clojure
-        uses: DeLaGuardo/setup-clojure@10.1
+        uses: DeLaGuardo/setup-clojure@13.0
         with:
           tools-deps: 'latest'
           cli: 'latest'
 
       - name: Cache Clojure dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-clojure-${{ hashFiles('**/deps.edn') }}
@@ -25,15 +25,15 @@ jobs:
   clojurescript-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '18'
           cache: 'npm'
 
       - name: Cache Clojure dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-clojure-${{ hashFiles('**/shadow-cljs.edn') }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -32,6 +32,12 @@ jobs:
           node-version: '18'
           cache: 'npm'
 
+      - name: Cache Clojure dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-clojure-${{ hashFiles('**/shadow-cljs.edn') }}
+
       - name: Install shadow-cljs
         run: npm install shadow-cljs
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,34 @@
+name: fusebox
+
+on: [push, pull_request]
+
+jobs:
+  clojure-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Clojure
+        uses: DeLaGuardo/setup-clojure@v2
+        with:
+          tools-deps: 'latest'
+      - name: Cache Clojure dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-clojure-${{ hashFiles('**/deps.edn') }}
+      - name: Run Clojure tests
+        run: clojure -M:dev:test
+
+  clojurescript-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          cache: 'npm'
+      - name: Install shadow-cljs
+        run: npm install shadow-cljs
+      - name: Run ClojureScript tests
+        run: npx shadow-cljs compile node-test

--- a/README.md
+++ b/README.md
@@ -233,12 +233,12 @@ For example the following spec turns the above rate limiter into a leaky bucket:
   * eval-count
   * exec-duration-ms
   * the exception/failing value
-* `::success?` - (Optional) A function which takes a return value and determines
-                 whether it was successful. If false, body is retried.
-                 Defaults to `(constantly true)`.
-                 If the retried code keeps returning non-truthy value, and not
-                 throw exceptions, the last result can be found in the exception's
-                 data under `::retry/val` key.
+* `::retry/success?` - (Optional) A function which takes a return value and determines
+                       whether it was successful. If false, body is retried.
+                       Defaults to `(constantly true)`.
+                       If the retried code keeps returning non-truthy value, and not
+                       throw exceptions, the last result can be found in the exception's
+                       data under `::retry/val` key.
 
 There are a few functions in `com.potetm.fusebox.retry` that will help you write
 a `::retry/delay` fn:

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ For example the following spec turns the above rate limiter into a leaky bucket:
                  Defaults to `(constantly true)`.
                  If the retried code keeps returning non-truthy value, and not
                  throw exceptions, the last result can be found in the exception's
-                 data under `::retry/last-result` key.
+                 data under `::retry/val` key.
 
 There are a few functions in `com.potetm.fusebox.retry` that will help you write
 a `::retry/delay` fn:

--- a/README.md
+++ b/README.md
@@ -236,6 +236,9 @@ For example the following spec turns the above rate limiter into a leaky bucket:
 * `::success?` - (Optional) A function which takes a return value and determines
                  whether it was successful. If false, body is retried.
                  Defaults to `(constantly true)`.
+                 If the retried code keeps returning non-truthy value, and not
+                 throw exceptions, the last result can be found in the exception's
+                 data under `::retry/last-result` key.
 
 There are a few functions in `com.potetm.fusebox.retry` that will help you write
 a `::retry/delay` fn:
@@ -597,6 +600,11 @@ that you can pass to `fetch` to properly terminate network calls:
             (js-obj
               "signal" (.-signal abort-controller))))
 ```
+
+### Local testing
+
+- To run Clojure tests, run `clj -M:dev:test`
+- To run Clojurescript tests: `shadow-cljs compile node-test`
 
 ## Acknowledgements
 This library pulls heavily from [Resilience4J](https://resilience4j.readme.io/). I owe

--- a/deps.edn
+++ b/deps.edn
@@ -1,15 +1,15 @@
 {:paths ["src"]
 
- :deps {org.clojure/clojure {:mvn/version "1.11.4"}
+ :deps {org.clojure/clojure {:mvn/version "1.12.0"}
         org.clojure/tools.logging {:mvn/version "1.3.0"}}
 
  :aliases {:dev {:extra-paths ["dev" "resources-dev" "test" "target/classes"]
                  :jvm-opts ["-Dlogback.configurationFile=logback-dev.xml"]
                  :extra-deps {nrepl/nrepl {:mvn/version "1.3.0"}
-                              thheller/shadow-cljs {:mvn/version "2.28.10"}
+                              thheller/shadow-cljs {:mvn/version "2.28.20"}
 
                               org.clojure/clojurescript {:mvn/version "1.11.132"}
-                              ring/ring-jetty-adapter {:mvn/version "1.10.0"}
+                              ring/ring-jetty-adapter {:mvn/version "1.13.0"}
                               org.clojure/test.check {:mvn/version "1.1.1"}
                               io.github.resilience4j/resilience4j-all {:mvn/version "2.2.0"}
                               criterium/criterium {:mvn/version "0.4.6"}
@@ -18,10 +18,10 @@
                               com.hypirion/clj-xchart {:mvn/version "0.2.0"}
 
 
-                              org.clojure/tools.logging {:mvn/version "1.2.4"}
-                              org.slf4j/slf4j-api {:mvn/version "2.0.13"}
-                              org.slf4j/log4j-over-slf4j {:mvn/version "2.0.13"}
-                              ch.qos.logback/logback-classic {:mvn/version "1.5.6"}}}
+                              org.clojure/tools.logging {:mvn/version "1.3.0"}
+                              org.slf4j/slf4j-api {:mvn/version "2.0.16"}
+                              org.slf4j/log4j-over-slf4j {:mvn/version "2.0.16"}
+                              ch.qos.logback/logback-classic {:mvn/version "1.5.12"}}}
 
            :test {:extra-paths ["test"]
                   :extra-deps {io.github.cognitect-labs/test-runner {:git/tag "v0.5.1"
@@ -29,8 +29,8 @@
                   :main-opts ["-m" "cognitect.test-runner"]
                   :exec-fn cognitect.test-runner.api/test}
 
-           :build {:extra-deps {io.github.clojure/tools.build {:git/tag "v0.10.4"
-                                                               :git/sha "31388ff"
+           :build {:extra-deps {io.github.clojure/tools.build {:git/tag "v0.10.6"
+                                                               :git/sha "52cf7d6"
                                                                :exclusions [org.slf4j/slf4j-nop]}
                                 slipset/deps-deploy {:mvn/version "0.2.2"
                                                      :exclusions [org.slf4j/slf4j-nop]}}

--- a/src/com/potetm/fusebox/cljs/retry.cljs
+++ b/src/com/potetm/fusebox/cljs/retry.cljs
@@ -70,7 +70,7 @@
                                                    {:com.potetm.fusebox/error :com.potetm.fusebox.error/retries-exhausted
                                                     ::num-tries n
                                                     ::exec-duration-ms ed
-                                                    ::last-result err
+                                                    ::val err
                                                     :com.potetm.fusebox/spec (util/pretty-spec spec)}
                                                    err))))))))))]
       (run 0))))

--- a/src/com/potetm/fusebox/cljs/retry.cljs
+++ b/src/com/potetm/fusebox/cljs/retry.cljs
@@ -70,6 +70,7 @@
                                                    {:com.potetm.fusebox/error :com.potetm.fusebox.error/retries-exhausted
                                                     ::num-tries n
                                                     ::exec-duration-ms ed
+                                                    ::last-result err
                                                     :com.potetm.fusebox/spec (util/pretty-spec spec)}
                                                    err))))))))))]
       (run 0))))

--- a/src/com/potetm/fusebox/retry.clj
+++ b/src/com/potetm/fusebox/retry.clj
@@ -67,20 +67,22 @@
                       (let [d (delay n'
                                      ed
                                      v)]
-                        (do (log/info "fusebox retrying"
-                                      {:count n'
-                                       :exec-duration ed
-                                       :delay-ms d})
-                            (Thread/sleep ^long d)
-                            (recur n')))
-                      (throw (ex-info "fusebox retries exhausted"
-                                      {::fb/error ::err/retries-exhausted
-                                       ::num-retries n
-                                       ::exec-duration-ms ed
-                                       ::fb/spec (util/pretty-spec spec)}
-                                      (when (instance? Throwable v)
-                                        v)))))))))))
-
+                        (log/info "fusebox retrying"
+                                  {:count n'
+                                   :exec-duration ed
+                                   :delay-ms d})
+                        (Thread/sleep ^long d)
+                        (recur n'))
+                      (let [cause (when (instance? Throwable v)
+                                    v)]
+                        (throw (ex-info "fusebox retries exhausted"
+                                        (cond-> {::fb/error ::err/retries-exhausted
+                                                 ::num-retries n
+                                                 ::exec-duration-ms ed
+                                                 ::fb/spec (util/pretty-spec spec)}
+                                          ;; Attach last return value only if it's not an exception
+                                          (not cause) (assoc ::last-result v))
+                                        cause)))))))))))
 
 (defn ^:deprecated retry*
   "DEPRECATED: This was an early mistake. It should have been named with-retry*."

--- a/src/com/potetm/fusebox/retry.clj
+++ b/src/com/potetm/fusebox/retry.clj
@@ -81,7 +81,7 @@
                                                  ::exec-duration-ms ed
                                                  ::fb/spec (util/pretty-spec spec)}
                                           ;; Attach last return value only if it's not an exception
-                                          (not cause) (assoc ::last-result v))
+                                          (not cause) (assoc ::val v))
                                         cause)))))))))))
 
 (defn ^:deprecated retry*

--- a/test/com/potetm/fusebox/cljs/retry_test.cljs
+++ b/test/com/potetm/fusebox/cljs/retry_test.cljs
@@ -79,7 +79,7 @@
                                           (yes {:some :thing :count (swap! invokes-count inc)}))))]
                       (catch e
                         (is (= {:some :thing :count 5}
-                               (-> (ex-data e) ::retry/last-result)))
+                               (-> (ex-data e) ::retry/val)))
                         (done)))))))
 
 

--- a/test/com/potetm/fusebox/cljs/retry_test.cljs
+++ b/test/com/potetm/fusebox/cljs/retry_test.cljs
@@ -65,6 +65,24 @@
           (done))))))
 
 
+(deftest retry-success?-constantly-failing-return-value
+  (testing "when ::retry/success? never succeeds last return value is included"
+    (async done
+           (let [invokes-count (atom 0)]
+             (p/await [ret (retry/with-retry (retry/init {::retry/retry? (fn [n ms ex]
+                                                                           (< n 5))
+                                                          ::retry/delay (constantly 1)
+                                                          ::retry/success? (fn [_]
+                                                                             false)})
+                             (p/promise (fn [yes no]
+
+                                          (yes {:some :thing :count (swap! invokes-count inc)}))))]
+                      (catch e
+                        (is (= {:some :thing :count 5}
+                               (-> (ex-data e) ::retry/last-result)))
+                        (done)))))))
+
+
 (deftest retry-count-arg
   (testing "retry count arg"
     (async done

--- a/test/com/potetm/fusebox/retry_test.clj
+++ b/test/com/potetm/fusebox/retry_test.clj
@@ -100,6 +100,25 @@
           (catch ExceptionInfo ei
             ::fail)))))
 
+  ;; NOTE: this needs to be ported CLJS somehow 🤔
+  (testing "provides last return value when retries are exhausted"
+    (let [counter (atom {:last-val 0})
+          result (try
+                   (retry/with-retry
+                     ;; retry up to 3 times, but never really 'succeed'
+                     (retry/init {::retry/retry? (fn [n _ms _ex]
+                                                   (<= n 3))
+                                  ::retry/delay (constantly 1)
+                                  ::retry/success? (fn [{:keys [last-val]}]
+                                                     (> last-val 5))})
+                     (swap! counter update :last-val inc))
+                   (catch ExceptionInfo ei
+                     ei))]
+
+      (is (= {:last-val 4}
+             (->> result
+                  ex-data
+                  ::retry/last-result)))))
 
   (testing "noop"
     (is (= 123

--- a/test/com/potetm/fusebox/retry_test.clj
+++ b/test/com/potetm/fusebox/retry_test.clj
@@ -118,7 +118,7 @@
       (is (= {:last-val 4}
              (->> result
                   ex-data
-                  ::retry/last-result)))))
+                  ::retry/val)))))
 
   (testing "noop"
     (is (= 123

--- a/test/com/potetm/fusebox/timeout_test.clj
+++ b/test/com/potetm/fusebox/timeout_test.clj
@@ -101,4 +101,4 @@
                       (catch ExceptionInfo ei
                         ::timeout)))]
       (is (= ret :hello!))
-      (is (< 100 t)))))
+      (is (<= 100 t)))))


### PR DESCRIPTION
As discussed on Slack :-) This improves retries by being able to unpack the last return value of a retried function/code which doesn't throw and doesn't pass the `success?` check.


- [x] Adds GH Actions config to run tests for both Clj and Cljs
- [x] when a retried code keeps failing `::retry/success?` check, include last return value under `::val` key in the "retries exhausted" exception
- [x] Update dependencies